### PR TITLE
Add support for iPadOS mouses and trackpads

### DIFF
--- a/Sources/RefreshControl.swift
+++ b/Sources/RefreshControl.swift
@@ -183,7 +183,7 @@ public class RefreshControl: UIControl {
         let recognizer = UIPanGestureRecognizer(target: self, action: #selector(viewPanned))
         
         if #available(iOS 13.4, *) {
-            recognizer.allowedScrollTypesMask = .all
+            recognizer.allowedScrollTypesMask = scrollView.panGestureRecognizer.allowedScrollTypesMask
         }
         
         recognizer.delegate = self

--- a/Sources/RefreshControl.swift
+++ b/Sources/RefreshControl.swift
@@ -181,6 +181,11 @@ public class RefreshControl: UIControl {
         originScrollViewContentInset = scrollView.contentInset
 
         let recognizer = UIPanGestureRecognizer(target: self, action: #selector(viewPanned))
+        
+        if #available(iOS 13.4, *) {
+            recognizer.allowedScrollTypesMask = .all
+        }
+        
         recognizer.delegate = self
         scrollView.addGestureRecognizer(recognizer)
 


### PR DESCRIPTION
Hello, when I attempted to refresh a collection view on an iPad with a trackpad, the refresh control would not be triggered.

This is due to `UIPanGestureRecognizer.allowedScrollTypesMask` not being set.
This pull request fixes this issue by copying the value from the scroll view's integrated pan gesture recognizer.
Documentation: https://developer.apple.com/documentation/uikit/uipangesturerecognizer/3538978-allowedscrolltypesmask